### PR TITLE
fix: downgrade go to 1.21.1 for compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,6 @@ func TestFlaky(t *testing.T) {
 }
 ```
 
-Use the env var `RUN_QUARANTINED_TESTS = "true"` to run these tests. All flaky tests get some info logged to `t.Log`, and also log `"flaky_test":"<TICKET-Number>"` with [t.Attr](https://pkg.go.dev/testing#T.Attr) for easy output parsing.
+Use the env var `RUN_QUARANTINED_TESTS = "true"` to run these tests.
+All flaky tests get some info logged to `t.Log`, and also emit test attributes in the same format as [`testing.TB.Attr()`](https://pkg.go.dev/testing#T.Attr) for easy output parsing by CI systems and test frameworks.
+  - Note: The `TB.Attr` functionality is mimicked for backwards compatibility, as it is only available in verisons >1.25.0.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/smartcontractkit/quarantine
 
-go 1.25.0
+go 1.21.1
 
 require github.com/stretchr/testify v1.10.0
 


### PR DESCRIPTION
### Changes

- Replace usage of `tb.Attr` with similar but backwards compatible logging method
  - Contents is more or less copied from actual source: https://cs.opensource.google/go/go/+/master:src/testing/testing.go;l=1501-1525

```
// Attr emits a test attribute associated with this test.
//
// The key must not contain whitespace.
// The value must not contain newlines or carriage returns.
//
// The meaning of different attribute keys is left up to
// continuous integration systems and test frameworks.
//
// Test attributes are emitted immediately in the test log,
// but they are intended to be treated as unordered.
func (c *common) Attr(key, value string) {
	if strings.ContainsFunc(key, unicode.IsSpace) {
		c.Errorf("disallowed whitespace in attribute key %q", key)
		return
	}
	if strings.ContainsAny(value, "\r\n") {
		c.Errorf("disallowed newline in attribute value %q", value)
		return
	}
	if c.chatty == nil {
		return
	}
	c.chatty.Updatef(c.name, "=== ATTR  %s %v %v\n", c.name, key, value)
}
```

### Motivation

Using `tb.Attr()` is causing us to upgrade to go versions where this tool is used.